### PR TITLE
[DO NOT MERGE] Prove PHP lint red path

### DIFF
--- a/tests/ci-negative-control.php
+++ b/tests/ci-negative-control.php
@@ -1,0 +1,3 @@
+<?php
+
+function githubReviewNegativeControl( {


### PR DESCRIPTION
Negative control for issue #1 finding 1.

This PR intentionally adds invalid PHP in `tests/ci-negative-control.php`. The required `Repository checks` job must fail at PHP lint and expose the parse error. The PR must never be merged; it will be closed and its branch deleted after the failed run is recorded.
