### PR TITLE
Fix Client Control settings save

### DIFF
--- a/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/SettingsController.php
@@ -18,7 +18,6 @@ class SettingsController extends ClientControlControllerBase
         'enforcement_mode',
         'destination_scope',
         'destination_alias',
-        'stale_neighbor_policy',
     ];
 
     public function getAction()

--- a/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/forms/general.xml
@@ -36,10 +36,6 @@
         <help>Fill this only when “Selected alias” is chosen above.</help>
     </field>
     <field>
-        <id>general.stale_neighbor_policy</id>
-        <type>hidden</type>
-    </field>
-    <field>
         <id>general.revision</id>
         <label>Settings version</label>
         <type>hidden</type>

--- a/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
+++ b/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
@@ -16,7 +16,6 @@
     .cc-section-intro { margin: 0 0 14px; color: #555; }
     .cc-technical { margin-top: 14px; }
     .cc-summary-counts { font-size: 15px; margin-bottom: 10px; }
-    tr[id="row_general.stale_neighbor_policy"],
     tr[id="row_general.revision"],
     tr[id="row_group.members"],
     tr[id="row_group.sync_state"],

--- a/tests/controller-load.php
+++ b/tests/controller-load.php
@@ -39,4 +39,10 @@ if (is_file('/usr/local/etc/inc/config.inc')) {
     foreach (['name', 'group', 'endpoints_text', 'enabled'] as $column) {
         check(in_array($column, $clientColumns, true), 'the client grid must expose column ' . $column);
     }
+    $settingsReflection = new ReflectionClass(Volgodon\ClientControl\Api\SettingsController::class);
+    $editableSettings = $settingsReflection->getReflectionConstant('EDITABLE_FIELDS')->getValue();
+    check(
+        !in_array('stale_neighbor_policy', $editableSettings, true),
+        'the fixed stale-neighbor policy must not be mutable through the settings API'
+    );
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -410,6 +410,19 @@ try {
 }
 check($acceptRejected, 'external drift can only be preserved as a conflict or explicitly restored');
 
+$generalForm = simplexml_load_file(
+    __DIR__ . '/../src/opnsense/mvc/app/controllers/Volgodon/ClientControl/forms/general.xml'
+);
+check($generalForm !== false, 'the settings form must be valid XML');
+$generalFieldIds = [];
+foreach ($generalForm->field as $field) {
+    $generalFieldIds[] = (string)$field->id;
+}
+check(
+    !in_array('general.stale_neighbor_policy', $generalFieldIds, true),
+    'the fixed stale-neighbor policy must not be serialized as an editable settings field'
+);
+
 require __DIR__ . '/controller-load.php';
 
 if (extension_loaded('gettext')) {


### PR DESCRIPTION
## Runtime reproduction
On TING 1.14.6_1 / OPNsense ABI 24.7, changing **Work mode** through `/ui/clientcontrol/` returned HTTP 200 with:

```json
{"result":"failed","validations":{"general.general.stale_neighbor_policy":"A value is required."}}
```

`stale_neighbor_policy` has one fixed supported value (`deny`), but the hidden form control serialized it as blank.

## Fix
- remove the fixed policy from the editable settings form and API allowlist;
- preserve the required model value rather than round-tripping it through a hidden UI field;
- remove the obsolete CSS selector;
- add form and API mutability contract checks.

## Verification
- PHP-WASM: 25 files parsed, 91 assertions;
- settings form XML and diff checks pass;
- after merge, deploy to the snapshotted TING gateway and repeat the exact browser save path.

No firewall policy or current managed object is changed by this PR.
