### PR TITLE
Show conflicts in Client Control plan summary

### DIFF
--- a/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
+++ b/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
@@ -592,10 +592,12 @@ $(document).ready(function () {
         const hasChanges = (plan.operations || []).some(function (operation) {
             return operation.action !== 'noop';
         });
+        const resultLabel = plan.status === 'ok' && !hasChanges
+            ? '{{ lang._('Settings are already active') }}'
+            : translatedLabel(planStatusLabels, plan.status);
         $('#plan-summary').text(
             '{{ lang._('Settings version') }}: ' + plan.revision + ' · ' +
-            '{{ lang._('Result') }}: ' + (hasChanges ?
-                translatedLabel(planStatusLabels, plan.status) : '{{ lang._('Settings are already active') }}')
+            '{{ lang._('Result') }}: ' + resultLabel
         );
         const tbody = $('#plan-rows').empty();
         (plan.operations || []).forEach(function (operation) {


### PR DESCRIPTION
## Runtime reproduction
On the isolated TING gateway, an owned alias was edited through the native OPNsense Alias UI. Client Control correctly returned:

```json
{"status":"conflict","counts":{"noop":15},"conflicts":[{"reason":"external_change","core_type":"alias"}]}
```

The apply button was correctly disabled, but the visible summary said **Settings are already active** because it selected the no-op label before considering `plan.status`.

## Fix
Use **Settings are already active** only for an `ok` plan with no changes. Conflict and invalid plans now retain their explicit status label even when every operation is a no-op.

## Verification
- PHP-WASM: 25 files parsed, 91 assertions;
- diff check passes;
- after merge, redeploy to the snapshotted isolated TING gateway and repeat the native-Alias drift scenario in the real browser UI.

The controlled drift was already restored through Client Control; runtime guard is verified and a follow-up `fail` plan is 16 no-ops with no conflicts.
