### PR TITLE
Bound audit reads and remove shallow conflict placeholder

### DIFF
--- a/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/DiagnosticsController.php
+++ b/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/DiagnosticsController.php
@@ -165,7 +165,7 @@ class DiagnosticsController extends ClientControlControllerBase
 
     public function auditAction()
     {
-        $audit = $this->auditRecords($this->getModel());
+        $audit = $this->auditRecords($this->getModel(), AuditLog::CONFIG_LIMIT);
         $records = [];
         foreach ($audit['records'] as $entry) {
             $records[] = [
@@ -179,7 +179,8 @@ class DiagnosticsController extends ClientControlControllerBase
         }
         return array_merge(
             $this->searchRecordsetBase($records, null, 'timestamp', null, SORT_NATURAL | SORT_FLAG_CASE),
-            $this->auditLogResponse($audit['audit_log'] === 'ok', $audit['audit_log_message'])
+            $this->auditLogResponse($audit['audit_log'] === 'ok', $audit['audit_log_message']),
+            ['history_window' => AuditLog::CONFIG_LIMIT]
         );
     }
 
@@ -199,7 +200,7 @@ class DiagnosticsController extends ClientControlControllerBase
         ], $this->auditLogResponse($audit['audit_log'] === 'ok', $audit['audit_log_message']));
     }
 
-    private function auditRecords($model)
+    private function auditRecords($model, $limit = null)
     {
         $configRecords = [];
         foreach ($model->audit->entry->iterateItems() as $uuid => $entry) {
@@ -216,7 +217,7 @@ class DiagnosticsController extends ClientControlControllerBase
             $auditLog = new AuditLog();
             $auditLog->probe();
             return array_merge(
-                ['records' => $auditLog->merge($configRecords)],
+                ['records' => $auditLog->merge($configRecords, $limit)],
                 $this->auditLogResponse(true)
             );
         } catch (\Throwable $error) {

--- a/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/Volgodon/ClientControl/Api/ServiceController.php
@@ -173,7 +173,6 @@ class ServiceController extends ClientControlControllerBase
                 'last_apply_message' => Translations::countSummary((string)$model->general->last_apply_message),
                 'managed_objects' => $counts,
                 'health_status' => in_array($syncState, ['error', 'conflict'], true) ? $syncState : 'ok',
-                'conflicts' => [],
                 'deep_check_required' => true,
                 'platform' => $platform,
             ], $auditLog);

--- a/src/opnsense/mvc/app/library/Volgodon/ClientControl/AuditLog.php
+++ b/src/opnsense/mvc/app/library/Volgodon/ClientControl/AuditLog.php
@@ -107,11 +107,17 @@ class AuditLog
     /**
      * Combine retained config records with the longer file-backed history.
      */
-    public function merge(array $configRecords)
+    public function merge(array $configRecords, $limit = null)
     {
+        if ($limit !== null) {
+            $limit = max(0, (int)$limit);
+            if ($limit === 0) {
+                return [];
+            }
+        }
         $records = [];
         $known = [];
-        foreach (array_merge($this->read(), $configRecords) as $record) {
+        foreach (array_merge($this->read($limit), $configRecords) as $record) {
             $record = $this->normalize($record);
             if ($record === null) {
                 continue;
@@ -122,14 +128,23 @@ class AuditLog
                 $records[] = $record;
             }
         }
+        if ($limit !== null) {
+            usort($records, function ($left, $right) {
+                return [$right['timestamp'], $right['uuid']] <=> [$left['timestamp'], $left['uuid']];
+            });
+            $records = array_slice($records, 0, $limit);
+        }
         return $records;
     }
 
     /**
      * Read the current JSON-lines file and uncompressed newsyslog generations.
      */
-    public function read()
+    public function read($limit = null)
     {
+        if ($limit !== null) {
+            return $this->readNewest(max(0, (int)$limit));
+        }
         $records = [];
         $known = [];
         foreach ($this->files() as $filename) {
@@ -139,21 +154,94 @@ class AuditLog
             }
             try {
                 while (($line = fgets($handle)) !== false) {
-                    $record = $this->normalize(json_decode(trim($line), true));
-                    if ($record === null) {
-                        continue;
-                    }
-                    $key = $this->recordKey($record);
-                    if (!isset($known[$key])) {
-                        $known[$key] = true;
-                        $records[] = $record;
-                    }
+                    $this->appendDecodedLine($line, $records, $known);
                 }
             } finally {
                 fclose($handle);
             }
         }
         return $records;
+    }
+
+    private function readNewest($limit)
+    {
+        if ($limit === 0) {
+            return [];
+        }
+        $records = [];
+        $known = [];
+        foreach ($this->files() as $filename) {
+            $this->readNewestFile($filename, $limit, $records, $known);
+            if (count($records) >= $limit) {
+                break;
+            }
+        }
+        return $records;
+    }
+
+    protected function readNewestFile($filename, $limit, array &$records, array &$known)
+    {
+        $handle = @fopen($filename, 'rb');
+        if ($handle === false) {
+            throw new RuntimeException('Unable to read the Client Control audit log.');
+        }
+        if (!flock($handle, LOCK_SH)) {
+            fclose($handle);
+            throw new RuntimeException('Unable to lock the Client Control audit log for reading.');
+        }
+        try {
+            if (fseek($handle, 0, SEEK_END) !== 0) {
+                throw new RuntimeException('Unable to seek in the Client Control audit log.');
+            }
+            $position = ftell($handle);
+            if ($position === false) {
+                throw new RuntimeException('Unable to inspect the Client Control audit log size.');
+            }
+            $buffer = '';
+            while ($position > 0 && count($records) < $limit) {
+                $length = min(8192, $position);
+                $position -= $length;
+                if (fseek($handle, $position, SEEK_SET) !== 0) {
+                    throw new RuntimeException('Unable to seek in the Client Control audit log.');
+                }
+                $chunk = fread($handle, $length);
+                if ($chunk === false || strlen($chunk) !== $length) {
+                    throw new RuntimeException('Unable to read the Client Control audit log.');
+                }
+                $buffer = $chunk . $buffer;
+                while (($newline = strrpos($buffer, "\n")) !== false) {
+                    $line = substr($buffer, $newline + 1);
+                    $buffer = substr($buffer, 0, $newline);
+                    if ($line !== '') {
+                        $this->appendDecodedLine($line, $records, $known);
+                    }
+                    if (count($records) >= $limit) {
+                        return;
+                    }
+                }
+            }
+            if ($position === 0 && $buffer !== '' && count($records) < $limit) {
+                $this->appendDecodedLine($buffer, $records, $known);
+            }
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    private function appendDecodedLine($line, array &$records, array &$known)
+    {
+        $record = $this->normalize(json_decode(trim($line), true));
+        if ($record === null) {
+            return false;
+        }
+        $key = $this->recordKey($record);
+        if (isset($known[$key])) {
+            return false;
+        }
+        $known[$key] = true;
+        $records[] = $record;
+        return true;
     }
 
     public static function compactSummary($summary, $limit = 255)

--- a/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
+++ b/src/opnsense/mvc/app/views/Volgodon/ClientControl/index.volt
@@ -536,12 +536,9 @@ $(document).ready(function () {
                 .attr('class', 'label ' +
                     (data.status === 'ok' ? 'label-success' :
                         (data.status === 'error' || data.status === 'conflict' ? 'label-danger' : 'label-default')));
-            const conflicts = data.conflicts || [];
-            const lastMessage = conflicts.length
-                ? conflicts.map(function (conflict) { return conflict.message; }).join(' | ')
-                : ((data.status === 'error' || data.status === 'conflict') && data.last_apply_message
-                    ? data.last_apply_message
-                    : (data.last_apply_time ? '{{ lang._('Last applied') }}: ' + formatDateTime(data.last_apply_time) : ''));
+            const lastMessage = (data.status === 'error' || data.status === 'conflict') && data.last_apply_message
+                ? data.last_apply_message
+                : (data.last_apply_time ? '{{ lang._('Last applied') }}: ' + formatDateTime(data.last_apply_time) : '');
             $('#cc-last-message').text(lastMessage);
             $('#cc-managed-count').text(Object.values(data.managed_objects || {}).reduce(function (sum, value) {
                 return sum + Number(value);

--- a/tests/controller-load.php
+++ b/tests/controller-load.php
@@ -139,6 +139,19 @@ if (is_file('/usr/local/etc/inc/config.inc')) {
         'a committed mutation must expose external audit degradation in its response');
     same('audit unavailable', $degradedAudit['audit_log_message'],
         'the audit degradation response must carry an operator-visible explanation');
+    $shallowStatus = $serviceController->statusAction();
+    check(!array_key_exists('conflicts', $shallowStatus),
+        'the shallow status endpoint must not claim an empty deep conflict result');
+    same(true, $shallowStatus['deep_check_required'],
+        'the shallow status endpoint must direct callers to the explicit deep check');
+    $diagnosticsReflection = new ReflectionClass(Volgodon\ClientControl\Api\DiagnosticsController::class);
+    $diagnosticsController = $diagnosticsReflection->newInstanceWithoutConstructor();
+    $diagnosticsController->request = new OPNsense\Mvc\Request();
+    $auditPage = $diagnosticsController->auditAction();
+    same(Volgodon\ClientControl\AuditLog::CONFIG_LIMIT, $auditPage['history_window'],
+        'interactive audit API responses must declare their bounded history window');
+    check(count($auditPage['rows']) <= Volgodon\ClientControl\AuditLog::CONFIG_LIMIT,
+        'interactive audit API responses must not read past the bounded history window');
     $reloadRuntime = $serviceReflection->getMethod('reloadRuntime');
     $reloadRuntime->setAccessible(true);
     $backend = $fakeBackend();

--- a/tests/run.php
+++ b/tests/run.php
@@ -50,7 +50,15 @@ if ($auditTemp === false || !unlink($auditTemp) || !mkdir($auditTemp, 0700)) {
 }
 try {
     $auditPath = $auditTemp . '/audit.log';
-    $auditLog = new AuditLog($auditPath);
+    $auditLog = new class($auditPath) extends AuditLog {
+        public $filesRead = [];
+
+        protected function readNewestFile($filename, $limit, array &$records, array &$known)
+        {
+            $this->filesRead[] = $filename;
+            parent::readNewestFile($filename, $limit, $records, $known);
+        }
+    };
     $longSummary = str_repeat('full audit detail ', 32);
     $auditRecord = [
         'uuid' => '11111111-1111-4111-8111-111111111111',
@@ -84,6 +92,54 @@ try {
     $compactSummary = AuditLog::compactSummary($longSummary);
     check(strlen($compactSummary) <= 255, 'the config audit fallback must remain bounded');
     check(str_ends_with($compactSummary, '...'), 'a truncated config summary must carry a marker');
+    $newestRecord = array_merge($auditRecord, [
+        'uuid' => '33333333-3333-4333-8333-333333333333',
+        'timestamp' => '2026-09-01T00:02:00Z',
+        'operation' => 'settings.set',
+        'summary' => str_repeat('newest current detail ', 500),
+        'result' => 'ok',
+    ]);
+    $auditLog->append([$newestRecord]);
+    $rotatedOlder = array_merge($auditRecord, [
+        'uuid' => '44444444-4444-4444-8444-444444444444',
+        'timestamp' => '2025-12-30T00:00:00Z',
+        'summary' => 'older rotated record',
+    ]);
+    $rotatedNewer = array_merge($auditRecord, [
+        'uuid' => '55555555-5555-4555-8555-555555555555',
+        'timestamp' => '2025-12-31T00:00:00Z',
+        'summary' => 'newer rotated record',
+    ]);
+    $oldestRecord = array_merge($auditRecord, [
+        'uuid' => '66666666-6666-4666-8666-666666666666',
+        'timestamp' => '2025-01-01T00:00:00Z',
+        'summary' => 'oldest generation record',
+    ]);
+    file_put_contents(
+        $auditPath . '.0',
+        json_encode($rotatedOlder) . "\n" . json_encode($rotatedNewer) . "\n"
+    );
+    file_put_contents($auditPath . '.1', json_encode($oldestRecord) . "\n");
+    $boundedAudit = $auditLog->read(3);
+    same(3, count($boundedAudit), 'interactive audit reads must stop at the requested window');
+    same($newestRecord['uuid'], $boundedAudit[0]['uuid'],
+        'bounded audit reads must start at the newest current-file record');
+    same($newestRecord['summary'], $boundedAudit[0]['summary'],
+        'bounded reverse reads must preserve a JSON record spanning multiple chunks');
+    same($rotatedNewer['uuid'], $boundedAudit[2]['uuid'],
+        'bounded audit reads must continue from the newest line in the next rotation');
+    same([$auditPath, $auditPath . '.0'], $auditLog->filesRead,
+        'bounded audit reads must not open generations older than the requested window');
+    $boundedMerge = $auditLog->merge([
+        array_merge($auditRecord, ['summary' => AuditLog::compactSummary($longSummary)]),
+        $configOnly,
+    ], 2);
+    same([$newestRecord['uuid'], $configOnly['uuid']], array_column($boundedMerge, 'uuid'),
+        'bounded audit merge must return the latest unique records across file and config fallbacks');
+    $fullAudit = $auditLog->read();
+    same(5, count($fullAudit), 'unbounded audit export reads must retain every generation');
+    check(in_array($oldestRecord['uuid'], array_column($fullAudit, 'uuid'), true),
+        'unbounded audit export must include the oldest retained generation');
     file_put_contents($auditTemp . '/not-a-directory', 'blocked');
     $probeFailed = false;
     try {


### PR DESCRIPTION
## Scope

- bound the interactive audit endpoint to the latest 200 unique records;
- read JSONL generations backwards and stop opening older generations once the window is full;
- preserve unbounded `client-control-audit-v1` export across every retained generation;
- remove the misleading empty `conflicts` field from shallow `/service/status`; keep explicit deep-plan conflicts unchanged;
- add chunk-boundary, rotation, file-open boundary, API-window, and shallow-status regression checks.

## Stack

- base PR: #20
- base commit: `77966ed`
- follow-up commit: `f40ce13`
- next stacked layer: #27 (`fix/issue-22-review-followups`)

Tracks #17 and #12. Automatic closure is delegated to root PR #9.

## Verification

- PHP 8.3 WASM suite: 210 assertions; all PHP sources parsed;
- canonical FreeBSD package build on TING: 1535 assertions;
- installed history endpoint returned `history_window=200`, 44 rows, and `audit_log=ok`; full export returned the same 44 retained rows without a bounded-window marker;
- regression fixture proves a three-row request opens only the current file and immediate rotation, while full export includes the oldest retained generation;
- installed shallow status returned `deep_check_required=true` and no `conflicts` property;
- real authenticated Chromium rendered seven Client Control tabs, the History table, healthy hidden warning state, and the recovered revision 30 as `in_sync`.

Automated and author-run verification only. No human review was performed or claimed.